### PR TITLE
proxytype config 'direct' to 'system'

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -1505,7 +1505,7 @@ function newChromeBrowser(options, callback){
     }
     else{
         capabilities.proxy = {
-            'proxyType': 'direct'
+            'proxyType': 'system'
         };
     }
     if(options.isRecorder){


### PR DESCRIPTION
Hey guys, I'm working on my thesis and recently started to use this project which I found lovely.

One thing that I found when recording tests was that I assumed the recorderBrowser would use the system proxy settings but this did not happen. 
The webdriver protocols (https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol) says:
'proxy - proxy object - Details of any proxy to use. If no proxy is specified, whatever the system's current or default state is used. The format is specified under Proxy JSON Object.' 

Thing is that you added a 'direct' configuration by default, may I know why? I was working with a proxy I made myself and went a little nuts trying to find out why my system settings were being bypassed. So unless there's a specific reason to use 'direct' I strongly recommend using 'system', which is what everyone would assume as a default configuration.

Thanks for reading me!