### PR TITLE
Add: support more expect type: notContain

### DIFF
--- a/chrome-extension/js/foreground.js
+++ b/chrome-extension/js/foreground.js
@@ -1899,7 +1899,7 @@
                     '<li><label>'+__('dialog_expect_type')+'</label><select id="uirecorder-expect-type" value=""><option>val</option><option>text</option><option>displayed</option><option>enabled</option><option>selected</option><option>attr</option><option>css</option><option>url</option><option>title</option><option>cookie</option><option>localStorage</option><option>sessionStorage</option><option>alert</option></select></li>',
                     '<li id="uirecorder-expect-dom-div"><label>'+__('dialog_expect_dom')+'</label><input id="uirecorder-expect-dom" type="text" /></li>',
                     '<li id="uirecorder-expect-param-div"><label>'+__('dialog_expect_param')+'</label><input id="uirecorder-expect-param" type="text" /></li>',
-                    '<li><label>'+__('dialog_expect_compare')+'</label><select id="uirecorder-expect-compare"><option>equal</option><option>notEqual</option><option>contain</option><option>above</option><option>below</option><option>match</option><option>notMatch</option></select></li>',
+                    '<li><label>'+__('dialog_expect_compare')+'</label><select id="uirecorder-expect-compare"><option>equal</option><option>notEqual</option><option>contain</option><option>notContain</option><option>above</option><option>below</option><option>match</option><option>notMatch</option></select></li>',
                     '<li><label>'+__('dialog_expect_to')+'</label><textarea id="uirecorder-expect-to"></textarea></li>',
                     '</ul>'
                 ];

--- a/chrome-extension/js/mobile.js
+++ b/chrome-extension/js/mobile.js
@@ -255,7 +255,7 @@
             '<li><label>'+__('dialog_expect_sleep')+'</label><input id="expectSleep" type="text" /> ms</li>',
             '<li><label>'+__('dialog_expect_type')+'</label><select id="expectType" value=""><option>text</option></select></li>',
             '<li><label>'+__('dialog_expect_path')+'</label><input id="expectPath" type="text" /></li>',
-            '<li><label>'+__('dialog_expect_compare')+'</label><select id="expectCompare"><option>equal</option><option>notEqual</option><option>contain</option><option>above</option><option>below</option><option>match</option><option>notMatch</option></select></li>',
+            '<li><label>'+__('dialog_expect_compare')+'</label><select id="expectCompare"><option>equal</option><option>notEqual</option><option>contain</option><option>notContain</option><option>above</option><option>below</option><option>match</option><option>notMatch</option></select></li>',
             '<li><label>'+__('dialog_expect_to')+'</label><textarea id="expectTo"></textarea></li>',
             '</ul>'
         ];

--- a/lib/start.js
+++ b/lib/start.js
@@ -524,6 +524,9 @@ function startRecorder(options){
                                     case 'contain':
                                         arrCodes.push('       .should.contain(_(\`'+escapeStr(codeExpectTo)+'\`));');
                                         break;
+                                    case 'notContain':
+                                        arrCodes.push('       .should.not.contain(_(\`'+escapeStr(codeExpectTo)+'\`));');
+                                        break;
                                     case 'above':
                                         arrCodes.push('       .should.above(_(\`'+escapeStr(codeExpectTo)+'\`));');
                                         break;
@@ -557,6 +560,9 @@ function startRecorder(options){
                                         break;
                                     case 'contain':
                                         value.should.contain(getVarStr(eval('\`'+expectTo+'\`')));
+                                        break;
+                                    case 'notContain':
+                                        value.should.not.contain(getVarStr(eval('\`'+expectTo+'\`')));
                                         break;
                                     case 'above':
                                         value.should.above(getVarStr(eval('\`'+expectTo+'\`')));
@@ -772,6 +778,9 @@ function startRecorder(options){
                                     case 'contain':
                                         arrCodes.push('       .should.contain(_(\`'+escapeStr(codeExpectTo)+'\`));');
                                         break;
+                                    case 'notContain':
+                                        arrCodes.push('       .should.not.contain(_(\`'+escapeStr(codeExpectTo)+'\`));');
+                                        break;
                                     case 'above':
                                         arrCodes.push('       .should.above(_(\`'+escapeStr(codeExpectTo)+'\`));');
                                         break;
@@ -844,6 +853,9 @@ function startRecorder(options){
                                             break;
                                         case 'contain':
                                             value.should.contain(getVarStr(eval('\`'+expectTo+'\`')));
+                                            break;
+                                        case 'notContain':
+                                            value.should.not.contain(getVarStr(eval('\`'+expectTo+'\`')));
                                             break;
                                         case 'above':
                                             value.should.above(getVarStr(eval('\`'+expectTo+'\`')));


### PR DESCRIPTION
The expect type "notContain" can be useful when you delete something on page and want to ensure it's really removed.