### PR TITLE
feat: support custom template & webdriverConfig

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -1509,8 +1509,7 @@ function startRecorder(options){
                     fs.writeFileSync(testFile, testContent);
                 }
                 else{
-                    var tempalteFile = path.resolve(__dirname, '../template/'+(mobile?'jwebdriver-mobile':'jwebdriver')+'.js');
-                    var templateContent = fs.readFileSync(tempalteFile).toString();
+                    var templateContent = getTemplateContent(mobile);
                     mkdirs(path.dirname(testFile));
                     var sizeCode = '';
                     if(browserSize){
@@ -1603,6 +1602,16 @@ function startRecorder(options){
             return str;
         }
     }
+}
+
+function getTemplateContent(isMobile) {
+    var templateName = isMobile ? 'jwebdriver-mobile.js' : 'jwebdriver.js';
+    var tempalteFilePath = path.resolve(__dirname, '../template/' + templateName);
+    var customTemplateFilePath = path.join(rootPath, './template/', templateName);
+    if (fs.existsSync(customTemplateFilePath)) {
+        tempalteFilePath = customTemplateFilePath;
+    }
+    return fs.readFileSync(tempalteFilePath).toString();
 }
 
 // get test root


### PR DESCRIPTION
初始化根目录提供 template 文件
```code
.
├── config.json
├── hosts
├── reports
├── screenshots
├── template
│   ├── jwebdriver-mobile.js
│   └── jwebdriver.js
└── uirecorder.log
```

读取自定义模板生成用例。