### PR TITLE
fix: idevice_id debug flag

### DIFF
--- a/template/jwebdriver-mobile.js
+++ b/template/jwebdriver-mobile.js
@@ -170,7 +170,7 @@ function getDeviceList(platformName){
         // ios real device
         strText = cp.execSync('idevice_id -l').toString();
         strText.replace(/(.+)\r?\n/g, function(all, udid){
-            let deviceName = cp.execSync('idevice_id -d '+udid).toString();
+            let deviceName = cp.execSync('idevice_id '+udid).toString();
             deviceName = deviceName.replace(/\r?\n/g, '');
             arrDeviceList.push({
                 name: deviceName,


### PR DESCRIPTION
fixes https://github.com/alibaba/macaca/issues/958
remove idevice_id `-d` flag to remove the debugging info causing `deviceName` to be too long.
before:
![Screenshot 2020-01-14 at 7 49 15 PM](https://user-images.githubusercontent.com/1209810/72342750-34017c00-3708-11ea-9f8f-4319483cc9ee.png)
after:
![Screenshot 2020-01-14 at 7 50 54 PM](https://user-images.githubusercontent.com/1209810/72342756-3663d600-3708-11ea-8818-d2435ba29006.png)
